### PR TITLE
A few small improvements

### DIFF
--- a/experiments/chat/chat/forms.py
+++ b/experiments/chat/chat/forms.py
@@ -1,0 +1,7 @@
+from django.forms import ModelForm
+from chat.models import Room, Message
+
+class MessageForm(ModelForm):
+    class Meta:
+        model = Message
+        fields = ["text"]

--- a/experiments/chat/chat/templates/chat/message.html
+++ b/experiments/chat/chat/templates/chat/message.html
@@ -1,1 +1,8 @@
-<li id="message_{{ message.pk }}">{{ message.text }}</li>
+<li id="message_{{ message.pk }}">
+  {{ message.text }}
+  {% if turbo__is_http %}
+    (from HTTP)
+  {% elif turbo__is_websocket %}
+    (from WS)
+  {% endif %}
+</li>

--- a/experiments/chat/chat/templates/chat/message_form.html
+++ b/experiments/chat/chat/templates/chat/message_form.html
@@ -1,8 +1,11 @@
-<turbo-frame id="send-message">
-     <form method="post" action="{% url 'send' view.kwargs.pk %}" data-turbo-frame="messages">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" value="Send">
-    </form>
-</turbo-frame>
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Send a message</title>
+</head>
+<body>
+  <h1>Send a message</h1>
+  {% include "chat/message_form_frame.html" %}
+</body>
+</html>

--- a/experiments/chat/chat/templates/chat/message_form_frame.html
+++ b/experiments/chat/chat/templates/chat/message_form_frame.html
@@ -1,0 +1,7 @@
+<turbo-frame id="send-message">
+     <form method="post" action="{% url 'send' view.kwargs.pk %}">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" value="Send">
+    </form>
+</turbo-frame>

--- a/experiments/chat/chat/templates/chat/message_update.html
+++ b/experiments/chat/chat/templates/chat/message_update.html
@@ -1,5 +1,5 @@
-{#<turbo-stream action="append" target="message-list">#}
-{#  <template>#}
-{#    {% include 'chat/message.html' with message=message only %}#}
-{#  </template>#}
-{#</turbo-stream>#}
+<turbo-stream action="append" target="messages">
+  <template>
+    {% include 'chat/message.html' with message=message turbo__is_http=turbo__is_http turbo__is_websocket=turbo__is_websocket only %}
+  </template>
+</turbo-stream>

--- a/experiments/chat/chat/templates/chat/room_detail.html
+++ b/experiments/chat/chat/templates/chat/room_detail.html
@@ -13,16 +13,15 @@
 </head>
 <body>
 <h1>{{ room.name }}</h1>
-<turbo-channels-stream-source model="chat.Message" stream="room_id" value="{{ room.id }}">
-</turbo-channels-stream-source>
-<turbo-frame id="messages-frame">
-     <ul id="messages">
-        {% for message in room.messages.all %}
-            {% include "chat/message.html" with message=message only %}
-        {% endfor %}
-    </ul>
-</turbo-frame>
-<turbo-frame id="send-message" src="{% url 'send' room.id %}">
-</turbo-frame>
+<turbo-channels-stream-source model="chat.Message" stream="room_id" value="{{ room.id }}" />
+
+<ul id="messages">
+  {% for message in room.messages.all %}
+      {% include "chat/message.html" with message=message only %}
+  {% endfor %}
+</ul>
+
+{% include "chat/message_form_frame.html" %}
+
 </body>
 </html>

--- a/experiments/chat/manage.py
+++ b/experiments/chat/manage.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+sys.path.insert(1, os.path.join(sys.path[0], '../..'))
+
 
 def main():
     """Run administrative tasks."""

--- a/turbo/consumers.py
+++ b/turbo/consumers.py
@@ -54,7 +54,8 @@ class TurboStreamsConsumer(JsonWebsocketConsumer):
                     model_name.lower(): instance,
                     "action": stream_action,
                     "dom_target": target,
-                    "model_template": f"{app}/{model_name}.html"
+                    "model_template": f"{app}/{model_name}.html",
+                    "turbo__is_websocket": True,
                 })
             })
 

--- a/turbo/shortcuts.py
+++ b/turbo/shortcuts.py
@@ -1,0 +1,26 @@
+from django.shortcuts import render
+from django.http import HttpResponse
+
+def render_turbo(request, template_name, location, context=None, content_type="text/html", status=None, using=None):
+    # A request could be made from 2 places.
+
+    # Either it is a Turbo Frame that initiated the request: we can detect it with
+    # `turbo-stream` in the `Accept` header.
+    if "turbo-stream" in request.META['HTTP_ACCEPT']:
+        # Notify the template that this is a trubo stream response sent over HTTP
+        # (in opposition to turbo steams sent via websockets)
+        context["turbo__is_http"] = True
+
+        # Notify the turbo client that we are sending a turbo-stream message
+        # so the frontend does not try to redirect the user
+        content_type = '%s; turbo-stream;' % content_type
+
+        return render(request=request, template_name=template_name, context=context, content_type=content_type, status=status, using=using)
+
+    # Otherwise, the request was made by a plain old webpage, without any JS
+    # We return an HTTP 303 See Other like the Turbo documentation recommends
+    # so the user is redirected somwhere they can see the result of their action
+    else:
+        response = HttpResponse(content="", status=303)
+        response["Location"] = location
+        return response

--- a/turbo/shortcuts.py
+++ b/turbo/shortcuts.py
@@ -13,7 +13,7 @@ def render_turbo(request, template_name, location, context=None, content_type="t
 
         # Notify the turbo client that we are sending a turbo-stream message
         # so the frontend does not try to redirect the user
-        content_type = '%s; turbo-stream;' % content_type
+        content_type = f'{content_type}; turbo-stream;'
 
         return render(request=request, template_name=template_name, context=context, content_type=content_type, status=status, using=using)
 

--- a/turbo/tests.py
+++ b/turbo/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.


### PR DESCRIPTION
Hi 👋

First of all, thank you @davish for sharing your code 🤗

I made a bunch of small modifications bundled in a single PR (sorry if it's messy).

I wrote a helper function: [`render_turbo()`](https://github.com/hotwire-django/turbo-django/blob/no-js+minimal+helper/turbo/shortcuts.py#L4). That can be used when answering a form submit. If the request comes from trubo, it sends a turbo frame with the correct headers. Otherwise, it it comes from a plain request, it sends a 303 redirect

I also ensured that the demo is still working even when the JS is deactivated by including the form directly on the detail view but also in the /send view.

And some small details:
 * I removed some superfluous tags and attributes: `data-turbo-frame="messages"` in the form as well as an extra `<turbo-frame id="messages-frame">` that did nothing
 * I hacked `sys.path` in the experiment chat app so it can import `turbo` that is in the parent directory (i guess we'll do something prettier when we have a pip installable package)
 * I removed `turbo/migrations/__init__.py` and `turbo/tests.py` because they are empty at the moment