### PR TITLE
Update Turbo Stream integration to use model based streams

### DIFF
--- a/experiments/chat/chat/models.py
+++ b/experiments/chat/chat/models.py
@@ -7,6 +7,9 @@ class Room(models.Model):
 
 
 class Message(BroadcastableMixin, models.Model):
+    broadcast_to = ["room"]
+    broadcast_self = False
+
     room = models.ForeignKey(Room, related_name="messages", on_delete=models.CASCADE)
     text = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)

--- a/experiments/chat/chat/models.py
+++ b/experiments/chat/chat/models.py
@@ -1,9 +1,14 @@
 from django.db import models
+from django.urls import reverse
+
 from turbo.mixins import BroadcastableMixin
 
 
-class Room(models.Model):
+class Room(BroadcastableMixin, models.Model):
     name = models.CharField(max_length=255)
+
+    def get_absolute_url(self):
+        return reverse("detail", kwargs={"pk": self.pk})
 
 
 class Message(BroadcastableMixin, models.Model):

--- a/experiments/chat/chat/templates/chat/room.html
+++ b/experiments/chat/chat/templates/chat/room.html
@@ -1,0 +1,3 @@
+<div>
+    <h1 id="room_{{ room.pk }}">{{ room.name }}</h1>
+</div>

--- a/experiments/chat/chat/templates/chat/room_detail.html
+++ b/experiments/chat/chat/templates/chat/room_detail.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 <h1>{{ room.name }}</h1>
-<turbo-channels-stream-source model="chat.Message" stream="room_id" value="{{ room.id }}">
+<turbo-channels-stream-source model="chat.Room" pk="{{ room.pk }}">
 </turbo-channels-stream-source>
 <turbo-frame id="messages-frame">
      <ul id="messages">

--- a/experiments/chat/chat/templates/chat/room_detail.html
+++ b/experiments/chat/chat/templates/chat/room_detail.html
@@ -12,7 +12,10 @@
     {% include "turbo/head.html" %}
 </head>
 <body>
-<h1>{{ room.name }}</h1>
+<turbo-frame id="update-room">
+    {% include 'chat/room.html' %}
+    <a href="{% url 'update' room.pk %}">Edit</a>
+</turbo-frame>
 <turbo-channels-stream-source model="chat.Room" pk="{{ room.pk }}">
 </turbo-channels-stream-source>
 <turbo-frame id="messages-frame">

--- a/experiments/chat/chat/templates/chat/room_form.html
+++ b/experiments/chat/chat/templates/chat/room_form.html
@@ -1,0 +1,7 @@
+<turbo-frame id="update-room">
+     <form method="post" action="{% url 'update' view.kwargs.pk %}">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" value="Submit">
+    </form>
+</turbo-frame>

--- a/experiments/chat/chat/urls.py
+++ b/experiments/chat/chat/urls.py
@@ -5,5 +5,6 @@ from . import views
 urlpatterns = [
     path("", views.RoomList.as_view(), name="index"),
     path("<slug:pk>/", views.RoomDetail.as_view(), name="detail"),
+    path("<slug:pk>/edit", views.RoomUpdate.as_view(), name="update"),
     path("<slug:pk>/send", views.MessageCreate.as_view(), name="send"),
 ]

--- a/experiments/chat/chat/views.py
+++ b/experiments/chat/chat/views.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 from django.views.generic import ListView, DetailView
-from django.views.generic.edit import CreateView
+from django.views.generic.edit import CreateView, UpdateView
 from django.shortcuts import render, get_object_or_404
 from .models import Room, Message
 
@@ -13,6 +13,11 @@ class RoomList(ListView):
 class RoomDetail(DetailView):
     model = Room
     context_object_name = 'room'
+
+
+class RoomUpdate(UpdateView):
+    model = Room
+    fields = ["name"]
 
 
 class MessageCreate(CreateView):

--- a/turbo/__init__.py
+++ b/turbo/__init__.py
@@ -1,5 +1,11 @@
+from django.db.models import Model
+
 default_app_config = 'turbo.apps.TurboDjangoConfig'
 
 
-def get_broadcast_channel(model, stream, value):
-    return f"BROADCAST-{model}-{stream}-{value}"
+def make_channel_name(model_label, pk):
+    return f"BROADCAST-{model_label}-{pk}".lower()
+
+
+def channel_name_for_instance(instance: Model):
+    return make_channel_name(instance._meta.label, instance.pk)

--- a/turbo/consumers.py
+++ b/turbo/consumers.py
@@ -3,7 +3,7 @@ from asgiref.sync import async_to_sync
 from django.apps import apps
 from django.template.loader import render_to_string
 
-from turbo import get_broadcast_channel
+from turbo import make_channel_name
 
 
 class TurboStreamsConsumer(JsonWebsocketConsumer):
@@ -17,32 +17,20 @@ class TurboStreamsConsumer(JsonWebsocketConsumer):
         model = apps.get_model(model_label)
 
         pk = event["pk"]
-        stream = event["stream"]
-        model_action = event["action"]
-
+        action = event["action"]
 
         singular_name = model._meta.verbose_name.lower()
         plural_name = model._meta.verbose_name_plural.lower()
 
-        for request_id in self.requests[event["channel"]]:
+        for request_id in self.requests[event["channel_name"]]:
             subscription = self.subscriptions[request_id]
             list_target = subscription.get("list_target") or plural_name
             element_target = f'{subscription.get("element_prefix") or f"{singular_name}_"}{pk}'
 
-            if stream == "pk":
-                target = element_target
-                stream_action = "replace"
-            elif model_action == "CREATE":
-                target = list_target
-                stream_action = "append"
-            elif model_action == "UPDATE":
-                target = element_target
-                stream_action = "replace"
-            elif model_action == "DELETE":
-                target = element_target
-                stream_action = "remove"
+            if action == "append" or action == "prepend":
+                dom_target = list_target
             else:
-                return
+                dom_target = element_target
 
             instance = model.objects.get(pk=pk)
             app, model_name = model_label.lower().split(".")
@@ -52,25 +40,23 @@ class TurboStreamsConsumer(JsonWebsocketConsumer):
                 "data": render_to_string('turbo/stream.html', {
                     "object": instance,
                     model_name.lower(): instance,
-                    "action": stream_action,
-                    "dom_target": target,
+                    "action": action,
+                    "dom_target": dom_target,
                     "model_template": f"{app}/{model_name}.html"
                 })
             })
 
     def receive_json(self, content, **kwargs):
         model_label = content.get("model")
-        stream = content.get("stream")
-        value = content.get("value")
+        pk = content.get("pk")
         request_id = content.get("request_id")
 
-        channel = get_broadcast_channel(model_label.lower(), stream, value)
+        channel_name = make_channel_name(model_label, pk)
 
         self.subscriptions[request_id] = {
             "list_target": content.get("list_target"),
             "element_prefix": content.get("element_prefix")
         }
-        self.requests.setdefault(channel, []).append(request_id)
-        print(f"RECEIVED SUBSCRIPTION: {channel}")
-        self.groups.append(channel)
-        async_to_sync(self.channel_layer.group_add)(channel, self.channel_name)
+        self.requests.setdefault(channel_name, []).append(request_id)
+        self.groups.append(channel_name)
+        async_to_sync(self.channel_layer.group_add)(channel_name, self.channel_name)

--- a/turbo/mixins.py
+++ b/turbo/mixins.py
@@ -2,37 +2,34 @@ from asgiref.sync import async_to_sync
 
 from channels.layers import get_channel_layer
 
-from turbo import get_broadcast_channel
+from turbo import channel_name_for_instance
 
 
 class BroadcastableMixin(object):
+    broadcast_to = []  # Foreign Key fieldnames to broadcast updates for.
+    broadcast_self = True  # Whether or not to broadcast updates on this model's own stream.
+    inserts_by = "append"  # Whether to append or prepend when adding to a list (broadcasting to a foreign key).
 
-    def get_streams(self):
-        """
-        Allow subscribing to streams for objects by their primary key (single updates),
-        or any ForeignKey present on the model.
-        """
-        streams = ["pk"]
-        for field in self._meta.get_fields():
-            if field.get_internal_type() == 'ForeignKey':
-                streams.append(field.get_attname())
-        return streams
+    def _broadcast_to_instance(self, instance, action):
+        channel_layer = get_channel_layer()
+        channel_name = channel_name_for_instance(instance)
+        async_to_sync(channel_layer.group_send)(
+            channel_name,
+            {
+                "type": "notify",
+                "model": self._meta.label,
+                "pk": self.pk,
+                "action": action,
+                "channel_name": channel_name,
+            })
 
     def save(self, *args, **kwargs):
-        channel_layer = get_channel_layer()
-        action = "CREATE" if self._state.adding else "UPDATE"
+        action = self.inserts_by if self._state.adding else "replace"
         super().save(*args, **kwargs)
-        for stream in self.get_streams():
-            if hasattr(self, stream):
-                channel = get_broadcast_channel(self._meta.label.lower(), stream, getattr(self, stream))
-                print(f"SENDING ON {channel}")
-                async_to_sync(channel_layer.group_send)(
-                    channel,
-                    {
-                        "type": "notify",
-                        "model": self._meta.label,
-                        "pk": self.pk,
-                        "stream": stream,
-                        "action": action,
-                        "channel": channel,
-                    })
+        if self.broadcast_self:
+            self._broadcast_to_instance(self, "replace")
+
+        for field_name in self.broadcast_to:
+            if hasattr(self, field_name):
+                self._broadcast_to_instance(getattr(self, field_name), action)
+

--- a/turbo/templates/turbo/head.html
+++ b/turbo/templates/turbo/head.html
@@ -5,7 +5,7 @@ const socket = new ReconnectingWebSocket("ws://localhost:8000/ws/")
 
 class TurboChannelsStreamSource extends HTMLElement {
     static counter = 0;
-    request_id
+    request_id;
 
     constructor() {
       super();
@@ -38,12 +38,11 @@ class TurboChannelsStreamSource extends HTMLElement {
 
     get subscription() {
       const model = this.getAttribute("model")
-      const stream = this.getAttribute("stream")
-      const value = this.getAttribute("value")
+      const pk = this.getAttribute("pk")
       const list_target = this.getAttribute("list-target")
       const element_prefix = this.getAttribute("element-prefix")
 
-      return { model, stream, value, list_target, element_prefix }
+      return { model, pk, list_target, element_prefix }
     }
 }
 


### PR DESCRIPTION
This PR updates the `BroadcastableMixin` and `TurboStreamsConsumer` to bundle all updates for a given model into a single stream rather than require separate stream subscriptions to accomplish this.

This brings our `BroadcastableMixin` in line with the `Broadcastable` found in `turbo-rails`. A few options now can be set on a model which inherits from `BroadcastableMixin`:

- `broadcast_to`: List of foreign key fields whose streams should be broadcast to when this field updates.    
    - For example, in the chat demo, the `Message` model has `broadcast_to = ["room"]`, so when a message is created or updated, any clients subscribed to its room's stream receive updates.
- `broadcast_self`: Whether to broadcast updates on the model's own stream. Defaults to `True`. `Message` sets this to `False` since there's never an instance where we subscribe to updates for a single message.
- `inserts_by`: This can either be `append` or `prepend`. Defaults to `append`. Determines whether new instances will be append or prepended to a given list of instances.

One important TODO for another PR is allowing a custom template for a model. Right now it defaults to using `app/model.html` which is fine for demos but real applications should be able to customize this. Potentially even have this be a per-subscription option.

The `chat` demo has also been updated to include editing the room title in-line, just like the Hotwire video demo. Any feedback on either the code or the updated demo is appreciated!