### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.md
+recursive-include turbo/templates/turbo/templates *
+recursive-include turbo/static/turbo/js *


### PR DESCRIPTION
`templates` and `static` are not included when pip installing in 0.1.1.  This should help.