### PR TITLE
Corrects hotwire links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ _Note_: This is not ready for production. APIs likely to change dramatically. Pl
 - Django 3.1+
 - Channels 3.0+ (Optional for Turbo Stream support)
 
-This repository aims to help you integrate [Hotwire Turbo](https://turbo.hotwire.dev/) with Django. Inspiration taken from [@hotwired/turbo-rails](https://github.com/hotwired/turbo-rails).
+This repository aims to help you integrate [Hotwire Turbo](https://turbo.hotwired.dev/) with Django. Inspiration taken from [@hotwired/turbo-rails](https://github.com/hotwired/turbo-rails).
 Documentation can be found [here](https://turbo-django.readthedocs.io/en/latest/index.html) for the current integration.
 
-Discussions about a Django/Hotwire integration are happening on the [Hotwire forum](https://discuss.hotwire.dev/t/django-backend-support-for-hotwire/1570). And on Slack, which you can join by [clicking here!](https://join.slack.com/t/pragmaticmindsgruppe/shared_invite/zt-kl0e0plt-uXGQ1PUt5yRohLNYcVvhhQ)
+Discussions about a Django/Hotwire integration are happening on the [Hotwire forum](https://discuss.hotwired.dev/t/django-backend-support-for-hotwire/1570). And on Slack, which you can join by [clicking here!](https://join.slack.com/t/pragmaticmindsgruppe/shared_invite/zt-kl0e0plt-uXGQ1PUt5yRohLNYcVvhhQ)
 
 As we discover this new magic, you can expect to see a few repositories with experiments and demos appear in [@hotwire-django](https://github.com/hotwire-django). If you too are experimenting, we encourage you to ask a write access to the GitHub organization and to publish your work in a @hotwire-django repository.
 

--- a/doc/source/main.rst
+++ b/doc/source/main.rst
@@ -1,4 +1,4 @@
-This package provides helpers for server-side rendering of `Hotwired/Turbo <https://turbo.hotwire.dev/>`_ websocket based Streams.
+This package provides helpers for server-side rendering of `Hotwired/Turbo <https://turbo.hotwired.dev/>`_ websocket based Streams.
 
 **Disclaimer**: the Hotwired/Turbo client libraries are, at time of writing, still in Beta. We expect there will be breaking changes until the first stable release. This package, and the Turbo client, should therefore be used with caution in a production environment. The version used in testing is *@hotwired/turbo==7.0.0-beta.2*.
 
@@ -12,7 +12,7 @@ Turbo for Django
 ================
 
 This repository aims to provide utilities for working with
-`Turbo <https://turbo.hotwire.dev>`__
+`Turbo <https://turbo.hotwired.dev>`__
 with the Django web framework.
 
 Setup
@@ -28,7 +28,7 @@ Turbo Streams
 -------------
 
 Currently, the repository contains utilities for working with
-`Turbo Streams <https://turbo.hotwire.dev/handbook/streams>`__ over
+`Turbo Streams <https://turbo.hotwired.dev/handbook/streams>`__ over
 Websockets, the one part of
 Turbo which requires a specific integration with the backend framework
 to function. In Django's

--- a/experiments/chat/README.md
+++ b/experiments/chat/README.md
@@ -1,7 +1,7 @@
 # Django Hotwire Demo
 
-This repository contains a demonstration of [Hotwire](https://hotwire.dev), specifically the three components of
-[Turbo](https://turbo.hotwire.dev) to build a realtime chat app in Django with only server-side custom code. It makes use
+This repository contains a demonstration of [Hotwire](https://hotwired.dev), specifically the three components of
+[Turbo](https://turbo.hotwired.dev) to build a realtime chat app in Django with only server-side custom code. It makes use
 of Django Channels for websocket support.
 
 To run this demo, after cloning the repository:


### PR DESCRIPTION
Links to https://hotwire.dev are failing.  Updated to https://hotwired.dev