### PR TITLE
correct headings weight

### DIFF
--- a/doc/source/topics/components.rst
+++ b/doc/source/topics/components.rst
@@ -8,13 +8,13 @@ Components are a subclass of `Stream` that simplifies implementation of streams.
 
 
 Creating a Component
---------------------
+====================
 
 Components are a type of stream with a template.  As components are a type of stream, components must be either be created in or imported to `streams.py` to be registered.
 
 
 Quick example
-=============
+-------------
 
 .. code-block:: python
     :caption: app/streams.py
@@ -74,7 +74,7 @@ To stream updated content to the view, open a python terminal, instanciate the c
 
 
 Full example
-=============
+------------
 
 .. code-block:: python
     :caption: app/streams.py


### PR DESCRIPTION
I just was confused by the BroadcastComponent and UserBroadcastComponent with their "Example" subheadings being bigger as the headings themselves.
It's just because you first introduced --- as underline and THEN ===, so rst/sphinx mixes them up later.

I hope it's ok this way and you meant it so, maybe the two first headings could be even too. But at least now the (User)BroadcastComponent sections are better readable.